### PR TITLE
Kafka config

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -21,7 +21,9 @@ config :logger, :console,
 
 
 config :kafka_ex,
-  brokers: [{System.get_env("KAFKA_BROKER_HOST"), System.get_env("KAFKA_BROKER_PORT")}],
+  brokers: System.get_env("KAFKA_BROKERS_HOST") # expected to be comma separated list of broker_host:port
+            |> String.split(",")
+            |> Enum.map(fn(broker)-> List.to_tuple(String.split(broker, ":")) end ),
   consumer_group: System.get_env("KAFKA_CONSUMER_GROUP"),
   disable_default_worker: true,
   sync_timeout: 1000 #Timeout used synchronous requests from kafka. Defaults to 1000ms.

--- a/config/config.exs
+++ b/config/config.exs
@@ -21,8 +21,8 @@ config :logger, :console,
 
 
 config :kafka_ex,
-  brokers: [{"192.168.99.100", 9092}],
-  consumer_group: "kafka_ex",
+  brokers: [{System.get_env("KAFKA_BROKER_HOST"), System.get_env("KAFKA_BROKER_PORT")}],
+  consumer_group: System.get_env("KAFKA_CONSUMER_GROUP"),
   disable_default_worker: true,
   sync_timeout: 1000 #Timeout used synchronous requests from kafka. Defaults to 1000ms.
 

--- a/config/config.exs
+++ b/config/config.exs
@@ -21,7 +21,7 @@ config :logger, :console,
 
 
 config :kafka_ex,
-  brokers: System.get_env("KAFKA_BROKERS_HOST") # expected to be comma separated list of broker_host:port
+  brokers: System.get_env("KAFKA_BROKERS") # expected to be comma separated list of broker_host:port
             |> String.split(",")
             |> Enum.map(fn(broker)-> List.to_tuple(String.split(broker, ":")) end ),
   consumer_group: System.get_env("KAFKA_CONSUMER_GROUP"),


### PR DESCRIPTION
# Problem

Get Kafka broker's url from environment variable.
# Solution

Now we expect `KAFKA_BROKERS` environment variable to be a comma separated list of `kafka_broker_host:port`. For example:

```
192.168.0.1:9092,192.168.0.1:9093
```
