### PR TITLE
Finish APR deployment

### DIFF
--- a/chef/Berksfile.lock
+++ b/chef/Berksfile.lock
@@ -50,7 +50,7 @@ GRAPH
     windows (>= 1.2.2)
   supervisor (0.4.12)
     python (>= 0.0.0)
-  windows (1.42.0)
+  windows (1.43.0)
     chef_handler (>= 0.0.0)
   yum (3.11.0)
   yum-epel (0.7.0)

--- a/chef/site-cookbooks/artsy_apr/recipes/deploy.rb
+++ b/chef/site-cookbooks/artsy_apr/recipes/deploy.rb
@@ -29,7 +29,9 @@ environment = {
   "MIX_ENV" => application_env,
   "MIX_HOME" => "/home/deploy/.mix",
   "MIX_ARCHIVES" => "/home/deploy/.mix/archives",
-  "HEX_HOME" => "/home/deploy/.hex"
+  "HEX_HOME" => "/home/deploy/.hex",
+  "USER" => deploy_user,
+  "HOME" => "/home/#{deploy_user}"
 }
 
 unless configuration["environment"].nil?

--- a/terraform/production.json
+++ b/terraform/production.json
@@ -9,7 +9,8 @@
         },
         "environment": {
           "KAFKA_BROKERS": "ec2-52-201-17-104.compute-1.amazonaws.com:9092",
-          "KAFKA_CONSUMER_GROUP": "apr-production"
+          "KAFKA_CONSUMER_GROUP": "apr-production",
+          "PORT": 4000
         }
       }
     }

--- a/terraform/production.json
+++ b/terraform/production.json
@@ -14,5 +14,8 @@
         }
       }
     }
+  },
+  "opsworks": {
+    "chef_log_level":"info"
   }
 }

--- a/terraform/production.tf
+++ b/terraform/production.tf
@@ -69,8 +69,6 @@ resource "aws_elb" "apr-production-http" {
         timeout             = 10
     }
 
-    internal                = false
-
 }
 
 resource "aws_proxy_protocol_policy" "apr-production-http-proxy-protocol" {

--- a/terraform/production.tf
+++ b/terraform/production.tf
@@ -58,7 +58,7 @@ resource "aws_elb" "apr-production-http" {
         instance_port      = 80
         instance_protocol  = "tcp"
         lb_port            = 80
-        lb_protocol        = "http"
+        lb_protocol        = "tcp"
     }
 
     health_check {

--- a/terraform/production.tf
+++ b/terraform/production.tf
@@ -69,7 +69,7 @@ resource "aws_elb" "apr-production-http" {
         timeout             = 10
     }
 
-    internal                = true
+    internal                = false
 
 }
 

--- a/terraform/production.tf
+++ b/terraform/production.tf
@@ -77,3 +77,13 @@ resource "aws_proxy_protocol_policy" "apr-production-http-proxy-protocol" {
   load_balancer = "${aws_elb.apr-production-http.name}"
   instance_ports = ["80"]
 }
+
+resource "aws_opsworks_instance" "apr-production-backend" {
+  stack_id = "${aws_opsworks_stack.apr-production.id}"
+  layer_ids = [
+    "${aws_opsworks_custom_layer.apr-backend.id}",
+  ]
+  instance_type = "t2.small"
+  state         = "running"
+
+}


### PR DESCRIPTION
Deployable!  mix is VERY opinionated about how it is compiled / run and I had a lot of build problems with users/environment vars - would in the future opt to use a build pipeline that produces artifacts via http://www.phoenixframework.org/docs/advanced-deployment  rather than build on each deploy.  There is a lot of weirdness like `su - deploy` in the runtime command like you see below, but this is working for the time being.

KAFKA_BROKERS / KAFKA_CONSUMER_GROUP / PORT env vars are set at runtime although in the logs I don't think it respects setting the consumer group correctly.  @ashkan18 this would be good to ensure we don't have different environments configured as a single consumer group (and thus balancing messages between them).

Set up terraform with the steps in `terraform/README.md` then run `terraform apply` to bring up the stack!
