### PR TITLE
Fix weird consuming issue by start consuming from latest offset

### DIFF
--- a/lib/apr.ex
+++ b/lib/apr.ex
@@ -13,7 +13,7 @@ defmodule Apr do
       # worker(Apr.Worker, [arg1, arg2, arg3]),
       worker(Task, [Apr.EventReceiver, :start_link, ["users"]], id: :users),
       worker(Task, [Apr.EventReceiver, :start_link, ["subscriptions"]], id: :subscriptions),
-      worker(Task, [Apr.EventReceiver, :start_link, ["inquiries"]], id: :inquiries),
+      worker(Task, [Apr.EventReceiver, :start_link, ["inquiries"]], id: :inquiries)
     ]
 
     # See http://elixir-lang.org/docs/stable/elixir/Supervisor.html

--- a/web/receivers/event_receiver.ex
+++ b/web/receivers/event_receiver.ex
@@ -5,13 +5,16 @@ defmodule Apr.EventReceiver do
 
   def start_link(channel) do
     KafkaEx.create_worker(String.to_atom(channel))
-    for message <- KafkaEx.stream(channel, 0, worker_name: String.to_atom(channel)), acceptable_message?(message.value) do
+    for message <- KafkaEx.stream(channel, 0, worker_name: String.to_atom(channel), offset: latest_offset), acceptable_message?(message.value) do
       proccessed_message = process_message message
       # broadcast a message to a channel
       Endpoint.broadcast("#{channel}", proccessed_message["verb"], proccessed_message)
     end
   end
 
+  def latest_offset do
+    List.first(List.first(List.first(KafkaEx.latest_offset("users", 0)).partition_offsets).offset)
+  end
   def acceptable_message?(message) do
     try do
       Poison.decode!(message)

--- a/web/receivers/event_receiver.ex
+++ b/web/receivers/event_receiver.ex
@@ -1,4 +1,3 @@
-require IEx
 defmodule Apr.EventReceiver do
   require Logger
 
@@ -14,7 +13,6 @@ defmodule Apr.EventReceiver do
   end
 
   def latest_offset(channel) do
-    IEx.pry
     KafkaEx.latest_offset(channel, 0)
       |> List.first
       |> Map.get(:partition_offsets)

--- a/web/receivers/event_receiver.ex
+++ b/web/receivers/event_receiver.ex
@@ -1,3 +1,4 @@
+require IEx
 defmodule Apr.EventReceiver do
   require Logger
 
@@ -5,16 +6,23 @@ defmodule Apr.EventReceiver do
 
   def start_link(channel) do
     KafkaEx.create_worker(String.to_atom(channel))
-    for message <- KafkaEx.stream(channel, 0, worker_name: String.to_atom(channel), offset: latest_offset), acceptable_message?(message.value) do
+    for message <- KafkaEx.stream(channel, 0, worker_name: String.to_atom(channel), offset: latest_offset(channel)), acceptable_message?(message.value) do
       proccessed_message = process_message message
       # broadcast a message to a channel
       Endpoint.broadcast("#{channel}", proccessed_message["verb"], proccessed_message)
     end
   end
 
-  def latest_offset do
-    List.first(List.first(List.first(KafkaEx.latest_offset("users", 0)).partition_offsets).offset)
+  def latest_offset(channel) do
+    IEx.pry
+    KafkaEx.latest_offset(channel, 0)
+      |> List.first
+      |> Map.get(:partition_offsets)
+      |> List.first
+      |> Map.get(:offset)
+      |> List.first
   end
+
   def acceptable_message?(message) do
     try do
       Poison.decode!(message)


### PR DESCRIPTION
Allright....

Did some testing this weekend and i was finally able to get metadata for `users` topic. Still normal stream didn't work, so ended up always try starting stream from current latest offset based on the time APR was started.

In case of APR this is actually fine but still need to figure out what happened there, my current guess is without passing `offset` KafkaEx had problem getting current offset and couldn't fetch when we added new broker and etc.

![screen shot 2016-07-18 at 10 53 02 am](https://cloud.githubusercontent.com/assets/1230819/16918961/d6165612-4cd5-11e6-9635-f4ce39320993.png)
