### PR TITLE
Fix not receiving events issue

### DIFF
--- a/config/prod.exs
+++ b/config/prod.exs
@@ -30,7 +30,7 @@ config :logger, level: :info
 config :kafka_ex,
   brokers: [{"ip-10-0-0-49.ec2.internal", 9092}, {"ip-10-0-0-248.ec2.internal", 9092}],
   consumer_group: System.get_env("KAFKA_CONSUMER_GROUP") || "kafka_ex",
-  disable_default_worker: true,
+  disable_default_worker: false,
   sync_timeout: 1000 #Timeout used synchronous requests from kafka. Defaults to 1000ms.
 
 # ## SSL Support


### PR DESCRIPTION
# Problem

APR hasn't been receiving messages.
# Solution

I originally thought it's the offset problem and maybe because of ssl changes we made, but reading https://github.com/kafkaex/kafka_ex/pull/127 it turns out we need to enable default worker otherwise we get `no process` error. Basically what this does is, it sets up `kafka` application (in elixir sense) when we start the app and this way we would have the process setup for connecting to Kafka.
# The unknown!

I'm not sure how we didn't have this problem before. I don't remember disabling this flag.
