### PR TITLE
add nginx to apr container and expose on port 80

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,6 @@ ENV PHOENIX_VERSION 1.2.0
 # install the Phoenix Mix archive
 RUN mix archive.install --force https://github.com/phoenixframework/archives/raw/master/phoenix_new-$PHOENIX_VERSION.ez
 
-
-
 RUN apt-get update && \
       apt-get -y install sudo
 
@@ -17,13 +15,19 @@ RUN apt-get update && \
 # See http://www.phoenixframework.org/docs/installation#section-node-js-5-0-0-
 RUN curl -sL https://deb.nodesource.com/setup_6.x | sudo -E bash - && apt-get update && sudo apt-get install -y nodejs
 
+RUN apt-get -y install nginx
+RUN rm -v /etc/nginx/nginx.conf
+RUN rm -v /etc/nginx/sites-enabled/default
+ADD conf/nginx.conf /etc/nginx/
+ADD conf/apr-backend.conf /etc/nginx/conf.d/
+
 ADD . /app
 WORKDIR /app
-ENV PORT 8081
+ENV PORT 4000
 ENV MIX_ENV prod
 RUN mix deps.get
 RUN mix compile
 RUN npm install
 RUN node node_modules/brunch/bin/brunch build --production
 RUN mix phoenix.digest
-CMD mix phoenix.server
+CMD service nginx start && mix phoenix.server

--- a/conf/apr-backend.conf
+++ b/conf/apr-backend.conf
@@ -1,0 +1,23 @@
+server {
+        listen *:80 proxy_protocol;
+
+        server_name _;
+
+        set_real_ip_from 0.0.0.0/0;
+
+        real_ip_header proxy_protocol;
+        proxy_set_header X-Real-IP       $proxy_protocol_addr;
+        proxy_set_header X-Forwarded-For $proxy_protocol_addr;
+
+        location / {
+                proxy_pass http://127.0.0.1:4000/;
+                proxy_read_timeout 90;
+                proxy_http_version 1.1;
+                proxy_set_header Upgrade $http_upgrade;
+                proxy_set_header Connection "upgrade";
+                proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+                proxy_set_header Host $host;
+                proxy_set_header  X-Forwarded-Proto   tcp;
+                proxy_set_header  X-NginX-Proxy       true;
+        }
+}

--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -1,0 +1,39 @@
+user www-data;
+worker_processes  1;
+
+error_log  /var/log/nginx/error.log;
+pid        /var/run/nginx.pid;
+
+events {
+  worker_connections  1024;
+}
+
+http {
+
+  include       /etc/nginx/mime.types;
+  default_type  application/octet-stream;
+
+  access_log    /var/log/nginx/access.log;
+
+  sendfile on;
+  tcp_nopush on;
+  tcp_nodelay on;
+
+  keepalive_timeout  65;
+
+  gzip  on;
+  gzip_http_version 1.0;
+  gzip_comp_level 2;
+  gzip_proxied any;
+  gzip_vary off;
+  gzip_types text/plain text/css application/x-javascript text/xml application/xml application/rss+xml application/atom+xml text/javascript application/javascript application/json text/mathml;
+  gzip_min_length  1000;
+  gzip_disable     "MSIE [1-6]\.";
+
+  server_names_hash_bucket_size 64;
+  types_hash_max_size 2048;
+  types_hash_bucket_size 64;
+
+  include /etc/nginx/conf.d/*.conf;
+  include /etc/nginx/sites-enabled/*;
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,11 @@
 web:
   build: .
-  command: mix phoenix.server
+  command: service nginx start && mix phoenix.server
   environment:
-    PORT: 8081
+    PORT: 4000
   volumes:
   - .:/app
   ports:
-  - "8081:8081"
+  - "80:80"
   volumes:
   - .:/app


### PR DESCRIPTION
Adding you guys so you can keep track of how i'm setting up APR

Need to run nginx inside the container (for proxy protocol WS) alongside phoenix.server.  Probably should run both under a single supervisor command but this works for now.

Going to merge this so CI builds then can try running on Prod k8s
