### PR TITLE
Fix offset issue

### DIFF
--- a/web/receivers/event_receiver.ex
+++ b/web/receivers/event_receiver.ex
@@ -5,11 +5,20 @@ defmodule Apr.EventReceiver do
 
   def start_link(channel) do
     KafkaEx.create_worker(String.to_atom(channel))
-    for message <- KafkaEx.stream(channel, 0, worker_name: String.to_atom(channel)), acceptable_message?(message.value) do
+    for message <- KafkaEx.stream(channel, 0, worker_name: String.to_atom(channel), offset: latest_offset(channel)), acceptable_message?(message.value) do
       proccessed_message = process_message message
       # broadcast a message to a channel
       Endpoint.broadcast("#{channel}", proccessed_message["verb"], proccessed_message)
     end
+  end
+
+  defp latest_offset(channel) do
+    KafkaEx.latest_offset(channel, 0)
+        |> List.first
+        |> Map.get(:partition_offsets)
+        |> List.first
+        |> Map.get(:offset)
+        |> List.first
   end
 
   def acceptable_message?(message) do


### PR DESCRIPTION
# Problem

We are not getting events anymore.
# Solution (Making event receiving great again)

I've seen this happening and I think it might be an issue with the consumer code, last time when this happened I had to explicitly find last read offset and use that in `stream` call to start from that offset and then we started receiving events again. We are currently using same logic on APRB and seems to be working fine.
