### PR TITLE
Return map in initMap function

### DIFF
--- a/assets/js/map.ts
+++ b/assets/js/map.ts
@@ -24,7 +24,7 @@ export const addArc = (map, allArcs, from, to, options={}) => {
 }
 
 export const initMap = (mapElementId) => {
-  new Datamap({
+  return new Datamap({
     element: document.getElementById(mapElementId),
     projection: "mercator",
     bubblesConfig: {


### PR DESCRIPTION
Missing returning the `DataMap` object in `initMap`.